### PR TITLE
Surrounded C methods with 'extern "C"' to make them usable from C++ code

### DIFF
--- a/include/espfs.h
+++ b/include/espfs.h
@@ -1,6 +1,10 @@
 #ifndef ESPFS_H
 #define ESPFS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
 	ESPFS_INIT_RESULT_OK,
 	ESPFS_INIT_RESULT_NO_IMAGE,
@@ -15,5 +19,9 @@ int espFsFlags(EspFsFile *fh);
 int espFsRead(EspFsFile *fh, char *buff, int len);
 int espFsSeek(EspFsFile *fh, long offset, int mode);
 void espFsClose(EspFsFile *fh);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hello. Please consider merging this minor change. It will make some of the capabilities usable form within C++ code. Thanks