### PR TITLE
Fix mkespfsimage being output into bin instead of mkespfsimage

### DIFF
--- a/mkespfsimage/CMakeLists.txt
+++ b/mkespfsimage/CMakeLists.txt
@@ -27,4 +27,4 @@ if (USE_GZIP_COMPRESSION)
     target_link_libraries(mkespfsimage ${ZLIB_LIBRARIES})
 endif (USE_GZIP_COMPRESSION)
 
-install(TARGETS mkespfsimage RUNTIME DESTINATION "bin")
+install(TARGETS mkespfsimage RUNTIME DESTINATION "mkespfsimage")


### PR DESCRIPTION
https://github.com/jkent/esp32-espfs/commit/8c95d5872c535e8ebf7039d0aa430fafcc296f3e removed the bin directory, but mkespfsimage was still being output to the bin directory, resulting in a file not found error when trying to compile