### PR TITLE
Strip leading \ on windows paths

### DIFF
--- a/mkespfsimage/main.c
+++ b/mkespfsimage/main.c
@@ -356,6 +356,7 @@ int main(int argc, char **argv) {
 			realName=fileName;
 			if (fileName[0]=='.') realName++;
 			if (realName[0]=='/') realName++;
+			if (realName[0]=='\\') realName++;
 			f=open(fileName, O_RDONLY|O_BINARY);
 			if (f>0) {
 				char *compName = "unknown";


### PR DESCRIPTION
On windows, leading \'s were not being stripped out, leading to a bunch of 404 errors when trying to use libesphttpd