### PR TITLE
Fix for sed error during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ add_dependencies(${COMPONENT_LIB} espfs_image)
 
 add_custom_command(OUTPUT src/espfs_image.c
     COMMAND xxd -i espfs_image.bin src/espfs_image.c
-    COMMAND sed -i "1s;^;const __attribute__((aligned(4))) ;" src/espfs_image.c
+    COMMAND sed -i '' "1s;^;const __attribute__((aligned(4))) ;" src/espfs_image.c
 
     DEPENDS espfs_image.bin
     VERBATIM


### PR DESCRIPTION
This addition fixes the unterminated substitute pattern error you receive when running a build with this component included on a BSD system and/or macOs