### PR TITLE
Added dummy target to avoid errors when compiling with CONFIG_ESPFS_P…

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -52,6 +52,8 @@ endif
 
 node_modules:
 	npm install --save-dev $(npm_PACKAGES)
+else
+node_modules:
 endif
 
 espfs_image.bin: $(FILES) node_modules mkespfsimage/$(MKESPFSIMAGE)


### PR DESCRIPTION
Compiling with CONFIG_ESPFS_PREPROCESS_FILES off leads to the following error

`make[1]: *** No rule to make target 'node_modules', needed by 'espfs_image.bin'. `

I've added a dummy `node_modules` target to avoid this. Perhaps there is a better way to define a target that does nothing, so open to suggestions on how this could be made better. 
