### PR TITLE
cmake: use working directory for espfs.paths

### DIFF
--- a/cmake/include.cmake
+++ b/cmake/include.cmake
@@ -52,7 +52,7 @@ function(define_target_espfs target dir output)
     add_custom_target(${target}_paths
         BYPRODUCTS ${dir}/espfs.paths
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/libespfs.dir/requirements.stamp
-        COMMAND ${python} ${libespfs_DIR}/tools/pathlist.py ${dir}
+        COMMAND ${python} ${libespfs_DIR}/tools/pathlist.py ${CMAKE_CURRENT_BINARY_DIR}/${dir}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Updating espfs.paths for ${target}"
         VERBATIM


### PR DESCRIPTION
cmake supports building in a directory that is different from the root
of the source repository. This is done by passing the source directory
as an argument to `cmake`.

For example:

    mkdir work
    cd work
    cmake ..
    make

Paths for commands need to be adapted to this relative directory.

The linker was already set up with this in mind, however the Python
program `pathlist.py` was writing the contents of `espfs.paths` to the
source directory, resulting in a dependency error when this was not the
same as the source directory.

This patch corrects `pathlist.py` so that it writes to the cmake working
directory rather than the source directory.