### PR TITLE
Add support for memory mapped files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ directory and within that directory run:
 `git clone --recursive https://github.com/jkent/libespfs`
 
 
-You can generate a filesystem using `tools/mkespfsiage.py`. The tool takes two
+You can generate a filesystem using `tools/mkespfsimage.py`. The tool takes two
 arguments, ROOT, the directory containing the files to generate from, and
 IMAGE, the output file for the image. The script references an espfs.yaml file
 in the image ROOT, with the default settings to not add it to the image. The
@@ -36,8 +36,8 @@ filters:
     '*': heatshrink
 ```
 
-There are 5 preprocessors (babel-convert, babel-minifiy, html-minifier,
-uglifycss, and uglifyjs) and there are two compressors (gzip and heatshrink).
+There are 6 preprocessors (babel-convert, babel-minifiy, html-minifier,
+uglifycss, uglifyjs and zeroify) and there are two compressors (gzip, heatshrink).
 These can be prefixed with 'no-' to disable them in more specific filters.
 There is also the commands 'discard' to prevent files from being added to the
 image, 'skip' to cancel all processing, 'no-preprocessing', and

--- a/espfs_defaults.yaml
+++ b/espfs_defaults.yaml
@@ -22,6 +22,9 @@ preprocessors:
         npm: uglify-js
         command: npx uglifyjs
 
+    zeroify:
+        command: python tools/zeroify.py
+
 compressors:
     gzip:
         level: 9

--- a/include/libespfs/espfs.h
+++ b/include/libespfs/espfs.h
@@ -138,6 +138,18 @@ ssize_t espfs_fread(
 );
 
 /**
+ * \brief Memory map an open file object
+ *
+ * \warning Does not work for HEATSHRINK compressed data
+ * \return A pointer to the file's data or NULL upon error
+ */
+void * espfs_mmap(
+    espfs_file_t *f, /** [in] espfs file */
+    size_t * len /** [out] file length in bytes if found */
+);
+
+
+/**
  * \brief Seek to a position within an open file object
  *
  * \return position in file or < 0 upon error

--- a/include/libespfs/espfs.h
+++ b/include/libespfs/espfs.h
@@ -138,18 +138,6 @@ ssize_t espfs_fread(
 );
 
 /**
- * \brief Memory map an open file object
- *
- * \warning Does not work for HEATSHRINK compressed data
- * \return A pointer to the file's data or NULL upon error
- */
-void * espfs_mmap(
-    espfs_file_t *f, /** [in] espfs file */
-    size_t * len /** [out] file length in bytes if found */
-);
-
-
-/**
  * \brief Seek to a position within an open file object
  *
  * \return position in file or < 0 upon error

--- a/include/libespfs/espfs_format.h
+++ b/include/libespfs/espfs_format.h
@@ -11,7 +11,7 @@
  * \brief Magic number used in the espfs file header
  */
 #define ESPFS_MAGIC 0x2B534645 /** EFS+ */
-#define ESPFS_VERSION_MAJOR 1
+#define ESPFS_VERSION_MAJOR 2
 #define ESPFS_VERSION_MINOR 0
 
 typedef struct espfs_fs_header_t espfs_fs_header_t;

--- a/src/espfs.c
+++ b/src/espfs.c
@@ -304,21 +304,6 @@ void espfs_fstat(espfs_file_t *f, espfs_stat_t *stat)
     stat->size = f->fh->file_len;
 }
 
-// Memory map an open file object
-void * espfs_mmap(espfs_file_t *f, size_t * len)
-{
-    assert(f != NULL);
-
-    if (f->fh->compression != ESPFS_COMPRESSION_NONE) {
-        return 0;
-    }
-    if (len != NULL) {
-        *len = f->fh->file_len;
-    }
-    return f->raw_start;
-}
-
-
 // Read len bytes from the given file into buf. Returns the actual amount of bytes read.
 ssize_t espfs_fread(espfs_file_t *f, void *buf, size_t len)
 {

--- a/src/espfs.c
+++ b/src/espfs.c
@@ -121,8 +121,8 @@ static uint32_t hash_path(const char *path)
     const uint8_t *p = (uint8_t *)path;
 
     while (*p) {
-        /* hash = hash * 33 + *p */
-        hash = (hash << 5) + hash + *p;
+        /* hash = hash * 257 + *p */
+        hash = (hash << 8) + hash + *p;
         p++;
     }
 
@@ -303,6 +303,21 @@ void espfs_fstat(espfs_file_t *f, espfs_stat_t *stat)
     stat->compression = f->fh->compression;
     stat->size = f->fh->file_len;
 }
+
+// Memory map an open file object
+void * espfs_mmap(espfs_file_t *f, size_t * len)
+{
+    assert(f != NULL);
+
+    if (f->fh->compression != ESPFS_COMPRESSION_NONE) {
+        return 0;
+    }
+    if (len != NULL) {
+        *len = f->fh->file_len;
+    }
+    return f->raw_start;
+}
+
 
 // Read len bytes from the given file into buf. Returns the actual amount of bytes read.
 ssize_t espfs_fread(espfs_file_t *f, void *buf, size_t len)

--- a/tools/mkespfsimage.py
+++ b/tools/mkespfsimage.py
@@ -19,7 +19,7 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
 espfs_fs_header_t = Struct('<IBBHIHH')
 # magic, len, version_major, version_minor, binary_len, num_objects, reserved
 ESPFS_MAGIC = 0x2B534645 # EFS+
-ESPFS_VERSION_MAJOR = 1
+ESPFS_VERSION_MAJOR = 2
 ESPFS_VERSION_MINOR = 0
 
 espfs_hashtable_entry_t = Struct('<II')

--- a/tools/mkespfsimage.py
+++ b/tools/mkespfsimage.py
@@ -114,7 +114,7 @@ def load_config(root):
 def hash_path(path):
     hash = 5381
     for c in path.encode('utf8'):
-        hash = ((hash << 5) + hash + c) & 0xFFFFFFFF
+        hash = ((hash << 8) + hash + c) & 0xFFFFFFFF
     return hash
 
 def make_pathlist(root):

--- a/tools/zeroify.py
+++ b/tools/zeroify.py
@@ -6,8 +6,16 @@ import sys
 
 
 def main():
-    if len(sys.argv) < 3:
+    if len(sys.argv) != 3 and len(sys.argv) != 1:
         print("Usage is ", sys.argv[0], " inputFile outputFileWithZero")
+        return
+
+    if len(sys.argv) == 1:
+        input_str = sys.stdin.read()
+        sys.stdout.write(input_str)
+        sys.stdout.flush()
+        b = bytearray(b'\0')
+        sys.stdout.buffer.write(b)
         return
 
     with open(sys.argv[1], 'rb') as i:

--- a/tools/zeroify.py
+++ b/tools/zeroify.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage is ", sys.argv[0], " inputFile outputFileWithZero")
+        return
+
+    with open(sys.argv[1], 'rb') as i:
+        binary = i.read()
+
+        with open(sys.argv[2], 'wb') as f:
+            f.write(binary)
+            b = bytearray(b'\0')
+            f.write(b)
+
+    return 
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Right now, there's only a small function addition to support memory mapped files and this PR adds this.
Usually, when reading a file from ESPFS, one will need to allocate a buffer in the heap to read a file into. 
For small files, it's ok, but for decent files, it can be painful on such limited memory device.

With this patch, you'll write the ESPFS to a SPI Flash's partition and let esp-idf memory map the partition. Then the patch adds a mmap_file function so you can get a read-only view of the file, without allocating in the heap.

Typically, this is useful for GUI stuff where you can store bitmap images in ESPFS, Lottie's JSON files and so on.

Fix #29 and #28