### PR TITLE
Windows fixes -- vfs.c and preprocess.py

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -35,7 +35,7 @@ function(target_add_frogfs target path)
 
     add_custom_target(frogfs_preprocess_${ARG_NAME}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${output}
-        COMMAND ${Python3_VENV} ${frogfs_DIR}/tools/preprocess.py ${config_yaml} ${CMAKE_CURRENT_SOURCE_DIR}/${path} ${output}
+        COMMAND ${Python3_VENV} ${frogfs_DIR}/tools/preprocess.py ${config_yaml} --root ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${path} ${output}
         DEPENDS ${PROJECT_BINARY_DIR}/CMakeFiles/venv ${PROJECT_BINARY_DIR}/CMakeFiles/venv_requirements.stamp ${ARG_CONFIG}
         BYPRODUCTS ${PROJECT_BINARY_DIR}/CMakeFiles/node_modules ${output} ${output}/.state ${output}/.config
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/CMakeFiles
@@ -74,7 +74,7 @@ function(declare_frogfs_bin path)
 
     add_custom_target(frogfs_preprocess_${ARG_NAME}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${output}
-        COMMAND ${Python3_VENV} ${frogfs_DIR}/tools/preprocess.py ${config_yaml} ${CMAKE_CURRENT_SOURCE_DIR}/${path} ${output}
+        COMMAND ${Python3_VENV} ${frogfs_DIR}/tools/preprocess.py ${config_yaml} --root ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${path} ${output}
         DEPENDS ${PROJECT_BINARY_DIR}/CMakeFiles/venv ${PROJECT_BINARY_DIR}/CMakeFiles/venv_requirements.stamp ${ARG_CONFIG}
         BYPRODUCTS ${PROJECT_BINARY_DIR}/CMakeFiles/node_modules ${output} ${output}/.state ${output}/.config
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/CMakeFiles

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -5,29 +5,22 @@ if(ESP_PLATFORM)
 endif()
 
 if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    find_package(Python3 REQUIRED COMPONENTS Interpreter)
-    # venv is not available on ESP_IDF on Windows
+    idf_build_get_property(python PYTHON)
     if(CMAKE_HOST_WIN32)
-        set(Python3_VENV ${Python3_EXECUTABLE})
-        add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
-            COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/CMakeFiles/venv
-            COMMENT "Initalizing Python virtualenv"
-        )
+        set(Python3_VENV ${PROJECT_BINARY_DIR}/CMakeFiles/venv/Scripts/python)
     else()
         set(Python3_VENV ${PROJECT_BINARY_DIR}/CMakeFiles/venv/bin/python)
-        add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp ${PROJECT_BINARY_DIR}/CMakeFiles/venv
-            COMMAND ${Python3_EXECUTABLE} -m venv ${PROJECT_BINARY_DIR}/CMakeFiles/venv
-            COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
-            COMMENT "Initalizing Python virtualenv"
-        )
     endif(CMAKE_HOST_WIN32)
+    add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp ${PROJECT_BINARY_DIR}/CMakeFiles/venv
+        COMMAND ${python} -m venv ${PROJECT_BINARY_DIR}/CMakeFiles/venv
+        COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
+        COMMENT "Initalizing Python virtualenv"
+    )
 
     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv_requirements.stamp
         COMMAND ${Python3_VENV} -mpip install -r ${frogfs_DIR}/requirements.txt --upgrade
         COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv_requirements.stamp
         DEPENDS ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp ${frogfs_DIR}/requirements.txt
-        BYPRODUCTS ${PROJECT_BINARY_DIR}/CMakeFiles/venv
         COMMENT "Installing Python requirements"
     )
 endif()

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -6,16 +6,24 @@ endif()
 
 if(NOT CMAKE_BUILD_EARLY_EXPANSION)
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
-    set(Python3_VENV ${PROJECT_BINARY_DIR}/CMakeFiles/venv/bin/python)
-
-    add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp ${PROJECT_BINARY_DIR}/CMakeFiles/venv
-        COMMAND ${Python3_EXECUTABLE} -m venv ${PROJECT_BINARY_DIR}/CMakeFiles/venv
-        COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
-        COMMENT "Initalizing Python virtualenv"
-    )
+    # venv is not available on ESP_IDF on Windows
+    if(CMAKE_HOST_WIN32)
+        set(Python3_VENV ${Python3_EXECUTABLE})
+        add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
+            COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
+            COMMENT "Initalizing Python virtualenv"
+        )
+    else()
+        set(Python3_VENV ${PROJECT_BINARY_DIR}/CMakeFiles/venv/bin/python)
+        add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp ${PROJECT_BINARY_DIR}/CMakeFiles/venv
+            COMMAND ${Python3_EXECUTABLE} -m venv ${PROJECT_BINARY_DIR}/CMakeFiles/venv
+            COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
+            COMMENT "Initalizing Python virtualenv"
+        )
+    endif(CMAKE_HOST_WIN32)
 
     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv_requirements.stamp
-        COMMAND ${PROJECT_BINARY_DIR}/CMakeFiles/venv/bin/pip install -r ${frogfs_DIR}/requirements.txt --upgrade
+        COMMAND ${Python3_VENV} -mpip install -r ${frogfs_DIR}/requirements.txt --upgrade
         COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv_requirements.stamp
         DEPENDS ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp ${frogfs_DIR}/requirements.txt
         COMMENT "Installing Python requirements"

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -11,6 +11,7 @@ if(NOT CMAKE_BUILD_EARLY_EXPANSION)
         set(Python3_VENV ${Python3_EXECUTABLE})
         add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
             COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/CMakeFiles/venv
             COMMENT "Initalizing Python virtualenv"
         )
     else()
@@ -26,6 +27,7 @@ if(NOT CMAKE_BUILD_EARLY_EXPANSION)
         COMMAND ${Python3_VENV} -mpip install -r ${frogfs_DIR}/requirements.txt --upgrade
         COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/CMakeFiles/venv_requirements.stamp
         DEPENDS ${PROJECT_BINARY_DIR}/CMakeFiles/venv.stamp ${frogfs_DIR}/requirements.txt
+        BYPRODUCTS ${PROJECT_BINARY_DIR}/CMakeFiles/venv
         COMMENT "Installing Python requirements"
     )
 endif()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 heatshrink2>=0.6.0
-hiyapyco>=0.4.16
-MarkupSafe==0.23
+hiyapyco>=0.5.0
+MarkupSafe==1.1.1
 sortedcontainers>=2.4.0

--- a/src/frogfs.c
+++ b/src/frogfs.c
@@ -19,7 +19,7 @@
 
 #if defined(ESP_PLATFORM)
 # include <esp_partition.h>
-# include <esp_spi_flash.h>
+# include <spi_flash_mmap.h>
 #endif
 
 #include <assert.h>

--- a/src/frogfs_priv.h
+++ b/src/frogfs_priv.h
@@ -7,7 +7,7 @@
 #include "frogfs/frogfs_format.h"
 
 #if defined(ESP_PLATFORM)
-# include <esp_spi_flash.h>
+#include "spi_flash_mmap.h"
 #endif
 
 #include <stdint.h>

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -70,7 +70,7 @@ static esp_err_t frogfs_get_empty(int *index)
     return ESP_ERR_NOT_FOUND;
 }
 
-static void frogfs_get_overlay(vfs_frogfs *vfs, char *overlay_path, char *path,
+static void frogfs_get_overlay(vfs_frogfs_t *vfs, char *overlay_path, const char *path,
                                size_t len)
 {
     size_t out_len;
@@ -427,8 +427,8 @@ static int vfs_frogfs_readdir_r(void *ctx, DIR *pdir, struct dirent *entry,
     if (vfs_frogfs->flags & VFS_FROGFS_USE_OVERLAY) {
         if (!dir->overlay_dir) {
             char overlay_path[256];
-            frogfs_get_overlay(vfs_frogfs, overlay_path + len, dir->path,
-                               sizeof(overlay_path) - len);
+            frogfs_get_overlay(vfs_frogfs, overlay_path, dir->path,
+                               sizeof(overlay_path));
             dir->overlay_dir = opendir(overlay_path);
             if (dir->overlay_dir == NULL) {
                 *out_dirent = NULL;
@@ -624,12 +624,12 @@ esp_err_t esp_vfs_frogfs_register(const esp_vfs_frogfs_conf_t *conf)
     vfs_frogfs->max_files = conf->max_files;
     strncpy(vfs_frogfs->base_path, conf->base_path,
             sizeof(vfs_frogfs->base_path) - 1);
-    vfs_frogfw->base_path[sizeof(vfs_frogfs->base_path) - 1] = '\0';
+    vfs_frogfs->base_path[sizeof(vfs_frogfs->base_path) - 1] = '\0';
     if (conf->overlay_path) {
         vfs_frogfs->flags |= VFS_FROGFS_USE_OVERLAY;
         strncpy(vfs_frogfs->overlay_path, conf->overlay_path,
                 sizeof(vfs_frogfs->overlay_path));
-        vfs_frogfw->overlay_path[sizeof(vfs_frogfs->overlay_path) - 1] = '\0';
+        vfs_frogfs->overlay_path[sizeof(vfs_frogfs->overlay_path) - 1] = '\0';
     }
 
     esp_err_t err = esp_vfs_register(vfs_frogfs->base_path, &vfs, vfs_frogfs);

--- a/tools/preprocess.py
+++ b/tools/preprocess.py
@@ -251,6 +251,10 @@ def preprocess(path, preprocessors):
             command = config['preprocessors'][preprocessor]['command']
             if command[0].startswith('tools/'):
                 command[0] = os.path.join(script_dir, command[0][6:])
+            # These are implemented as `.cmd` files on Windows, which explicitly
+            # requires them to be run under `cmd /c`
+            if os.name == 'nt':
+                command = ["cmd", "/c"] + command
             process = subprocess.Popen(command, stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE, shell=True)
             data = process.communicate(input=data)[0]

--- a/tools/preprocess.py
+++ b/tools/preprocess.py
@@ -217,8 +217,8 @@ def build_state(src_dir):
                 }
     return state
 
-def install_preprocessors():
-    global config, used_preprocessors
+def install_preprocessors(config, root_dir):
+    global used_preprocessors
 
     for name in used_preprocessors:
         preprocessor = config['preprocessors'][name]
@@ -227,7 +227,10 @@ def install_preprocessors():
             subprocess.check_call(install, shell=True)
         elif 'npm' in preprocessor:
             for npm in preprocessor['npm']:
-                if not os.path.exists(os.path.join('node_modules', npm)):
+                test_path = os.path.join(root_dir.replace('/', os.path.sep),
+                                         'node_modules',
+                                         npm.replace('/', os.path.sep))
+                if not os.path.exists(test_path):
                     subprocess.check_call(f'npm install {npm}', shell=True)
 
 def preprocess(path, preprocessors):
@@ -269,6 +272,7 @@ def main():
     parser.add_argument('src_dir', metavar='SRC', help='source directory')
     parser.add_argument('dst_dir', metavar='DST', help='destination directory')
     parser.add_argument('--config', help='user configuration')
+    parser.add_argument('--root', metavar='ROOT', help='build root directory')
     args = parser.parse_args()
 
     load_config(args.config)
@@ -276,7 +280,7 @@ def main():
     old_state = load_state(args.dst_dir)
     new_state = build_state(args.src_dir)
 
-    install_preprocessors()
+    install_preprocessors(config, args.root)
 
     old_paths = SortedSet(old_state.keys())
     new_paths = SortedSet(new_state.keys())


### PR DESCRIPTION
This patchset fixes two issues encountered when porting to use frogfs:

1. `preprocess.py` doesn't work correctly on Windows due to how Node.js implements its commands. The workaround is to prefix these commands with `cmd /c`.
2. `vfs.c` appears to be unimplemented, and contains a few typos. I have fixed these typos in order to get it to build, however I am unsure of what the `len` variable is supposed to be in:

```patch
diff --git a/src/vfs.c b/src/vfs.c
index ceb7ef9..dd0a54c 100644
@@ -427,8 +427,8 @@ static int vfs_frogfs_readdir_r(void *ctx, DIR *pdir, struct dirent *entry,
     if (vfs_frogfs->flags & VFS_FROGFS_USE_OVERLAY) {
         if (!dir->overlay_dir) {
             char overlay_path[256];
-            frogfs_get_overlay(vfs_frogfs, overlay_path + len, dir->path,
-                               sizeof(overlay_path) - len);
+            frogfs_get_overlay(vfs_frogfs, overlay_path, dir->path,
+                               sizeof(overlay_path));
             dir->overlay_dir = opendir(overlay_path);
             if (dir->overlay_dir == NULL) {
                 *out_dirent = NULL;
```

I do not have a solution to the lack of `venv` on ESP on Windows, aside from removing venv from `cmake/functions.cmake`, which works on my system.