### PR TITLE
Add support for gzip transformation and destination file renaming

### DIFF
--- a/tools/meta-transform-rename.py
+++ b/tools/meta-transform-rename.py
@@ -1,0 +1,13 @@
+import sys
+
+if __name__ == '__main__':
+    destname = sys.stdin.buffer.read()
+    if len(sys.argv) == 3:
+        name = destname.decode()
+        args = sys.argv[1].split('=')
+        # Append extension
+        if args[0] == '--ext':
+            sys.stdout.buffer.write(str.encode(name+"."+sys.argv[2]))
+        # Or prepend some value
+        elif args[0] == '--prepend':
+            sys.stdout.buffer.write(str.encode(sys.argv[2]+name))

--- a/tools/mkfrogfs.py
+++ b/tools/mkfrogfs.py
@@ -167,6 +167,10 @@ def load_transforms() -> dict:
                 name, _ = os.path.splitext(file[10:]) # strip off 'transform-'
                 path = os.path.join(dir, file)
                 xforms[name] = {'path': path}
+            if file.startswith('meta-transform-'):
+                name, _ = os.path.splitext(file[15:]) # strip off 'meta-transform-'
+                path = os.path.join(dir, file)
+                xforms[name] = {'path': path, 'meta':True}
     return xforms
 
 ### Stage 1 ###
@@ -306,8 +310,13 @@ def preprocess(ent: dict) -> None:
         for name, args in ent['transform'].items():
             print(f'           - {name}... ', file=stderr, end='', flush=True)
             transform = transforms[name]
-            data = pipe_script(transform['path'], args, data)
-            print('done', file=stderr)
+            if 'meta' in transform:
+                dest = pipe_script(transform['path'], args, str.encode(ent['dest'])).decode()
+                ent['dest'] = dest
+                print(f'done as {dest}', file=stderr)
+            else:
+                data = pipe_script(transform['path'], args, data)
+                print('done', file=stderr)
 
         if ent['compress']:
             name, args = ent['compress']

--- a/tools/transform-gzip.py
+++ b/tools/transform-gzip.py
@@ -1,0 +1,10 @@
+import sys
+import gzip
+
+if __name__ == '__main__':
+    while True:
+        chunk = sys.stdin.buffer.read()
+        if not chunk:
+            break
+        compressed = gzip.compress(chunk)
+        sys.stdout.buffer.write(compressed)


### PR DESCRIPTION
This PR is a feature request implementation.

Currently, there are numerous features for compressing in frogfs but all of them imply decompressing when opening the files on ESP32. 

This PR adds a way to compress a file (as a `transform` filter and not a `compress`), rename the compressed file (for example by appending `.z` to its name) and store it in compressed form but plain file in the partition. 

The use case is when you have a HTTP server running on the ESP32, you don't want to decompress a text file to compress again when sending (that's what happen when you use `compress` filter). With this PR, since the compressed file is stored as plain text, you can **access** / **mmap** it (no copy, no decompress, no heap) and send directly (provided you set the `Transfer-Encoding: gzip` header in your answer).  Since all HTTP clients support `gzip` encoding (mandatory in HTTP standard), it's a perfectly fine and standard operation.

In order to test it, you'll have to add a filter like this in your configuration file:
```yaml
filter:
  '*.js':
    - gzip
    - rename:
        ext: z
```

Typically, in your HTTP / web server code on ESP32, when asked for `file.js`, you can simple search for `file.js.z` and if found skip compressing and sending the file. Else, you'll open the `file.js` and compress/send as usual.


### Few remarks about the rename filter:

1. The rename filter is a meta transform. It doesn't work on the content of the stream but on the destination name. This means that it can't access the content of the stream.
2. This filter support 2 kind of arguments: `ext` that append this extension to original destination name and `prepend` that prepend the destination name with the argument's value. The former is useful to make `a.js.z` from `a.js` and the latter for making `_a.js` from `a.js`


### Pro and cons

It might seems not much, but removing the dependency on heatshrink and deflate/zlib on FrogFS component reduce the firmware size of ~17kB (twice or 3x that amount if factory + 2 APP partitions). Since it's very unlikely that compressing is useful on a ESP32, and the need to decompress is useless on a ROM filesystem for files that can be decompressed on the final client, this saves on 2 birds at a time, the text file isn't consuming costly flash space for not being compressed. 

Yet, if the file is required to be read by the ESP32, this is useless and one should balance if the compression saving overcome the zlib overhead.