### PR TITLE
Fix rename not accounted in the hash computation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ _run-time_ decompression cost.
 
 This means for an HTTP server, zlib (deflate), brotli (br) or gzip compressed
 files can be passed through untouched! This saves processing time and bandwidth.
+Beware however that some browsers don't accept brotli content other HTTP (only HTTPS).
 
 # Getting started with ESP-IDF
 

--- a/tools/mkfrogfs.py
+++ b/tools/mkfrogfs.py
@@ -347,6 +347,7 @@ def preprocess(ent: dict) -> None:
             if 'meta' in transform:
                 dest = pipe_script(transform['path'], args, str.encode(ent['dest'])).decode()
                 ent['dest'] = dest
+                ent['name'] = dest.split('/')[-1]
                 print(f'done as {dest}', file=stderr)
             else:
                 data = pipe_script(transform['path'], args, data) if isinstance(args, dict) else data
@@ -588,7 +589,7 @@ def append_hashtable() -> None:
     '''Generate hashtable for entries'''
     global data
 
-    hashed_entries = {djb2_hash(k): v for k,v in entries.items()}
+    hashed_entries = {djb2_hash(v['dest']): v for k,v in entries.items()}
     hashed_entries = dict(sorted(hashed_entries.items(), key=lambda e: e))
 
     for hash, ent in hashed_entries.items():


### PR DESCRIPTION
In the current code, if a rename transform is set up, the renamed file isn't findable directly via frogfs_get_entry (it's accessible via opendir/readdir).

This is because the hash was computed on the previous name (without renaming).
This patch solves the issue by using the destination name. So now, it's possible to get an entry directly and via opendir/readdir too. 