### PR TITLE
[WIP] Add zopfli as default program for deflate algorithm

### DIFF
--- a/tools/transform-deflate.py
+++ b/tools/transform-deflate.py
@@ -1,5 +1,9 @@
 import sys
-import zlib
+# Try to use zopfli first, else fallback to zlib
+try:
+    import zopfli.zlib as zlib
+except:
+    import zlib
 
 if __name__ == '__main__':
     while True:


### PR DESCRIPTION
**Don't merge this PR, since it contains a change that'll break users code.** 

This PR contains 2 commits. The first one is the a change to match esp-idf convention for `idf.py` target names.

In esp-idf, all targets you can run use dash for word separation, but frogfs uses underscore for the `generate_frogfs_bin` target (but not `frogfs-flash`). So the first commit rename the target to fit esp-idf's conventions (this was spotted by our CI tooling).

However, this is a breaking change for any user of frogfs (although, if they use `frogfs-flash`, it still works, so I would say it breaks developers of frogfs more).

The second commit is a dumb but useful one. If zopfli is present on the system, it'll use it instead of zlib for deflating the input files. zopfli is more efficient at compressing data while still generating deflate compatible stream (so it'll be decompressed perfectly by zlib or gzip or ...). For an embedded system, this is a simple way to pack more data in the filesystem's partition. If it's not present, it'll fallback to zlib.

I've modified the `requirements.txt` file to include zopfli so we can test it in our pipeline, but I'm not sure it's right (since it'll force all user to download zopfli). I don't know what you think here?  
 