### PR TITLE
Add frogs vfs deregister

### DIFF
--- a/include/frogfs/vfs.h
+++ b/include/frogfs/vfs.h
@@ -32,6 +32,13 @@ typedef struct frogfs_vfs_conf_t {
  */
 esp_err_t frogfs_vfs_register(const frogfs_vfs_conf_t *conf);
 
+/**
+ * \brief      Unmount an frogfs fs handle under a vfs path
+ * \param[in]  base_path vfs path to unmount the filesystem
+ * \return     ESP_OK if successful, ESP_ERR_NOT_FOUND if the vfs path is not found
+ */
+esp_err_t frogfs_vfs_deregister(const char *base_path);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -340,3 +340,27 @@ esp_err_t frogfs_vfs_register(const frogfs_vfs_conf_t *conf)
     s_frogfs_vfs[index] = vfs;
     return ESP_OK;
 }
+
+esp_err_t frogfs_vfs_deregister(const char *base_path)
+{
+    assert(base_path != NULL);
+
+    for (int i = 0; i < CONFIG_FROGFS_MAX_PARTITIONS; i++)
+    {
+        if (s_frogfs_vfs[i] != NULL)
+        {
+            if (strcmp(s_frogfs_vfs[i]->base_path, base_path) == 0)
+            {
+                esp_err_t err = esp_vfs_unregister(base_path);
+                if (err != ESP_OK)
+                {
+                    return err;
+                }
+                free(s_frogfs_vfs[i]);
+                s_frogfs_vfs[i] = NULL;
+                return ESP_OK;
+            }
+        }
+    }
+    return ESP_ERR_NOT_FOUND;
+}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -345,21 +345,19 @@ esp_err_t frogfs_vfs_deregister(const char *base_path)
 {
     assert(base_path != NULL);
 
-    for (int i = 0; i < CONFIG_FROGFS_MAX_PARTITIONS; i++)
-    {
-        if (s_frogfs_vfs[i] != NULL)
-        {
-            if (strcmp(s_frogfs_vfs[i]->base_path, base_path) == 0)
-            {
-                esp_err_t err = esp_vfs_unregister(base_path);
-                if (err != ESP_OK)
-                {
-                    return err;
-                }
-                free(s_frogfs_vfs[i]);
-                s_frogfs_vfs[i] = NULL;
-                return ESP_OK;
+    for (int i = 0; i < CONFIG_FROGFS_MAX_PARTITIONS; i++) {
+        if (s_frogfs_vfs[i] == NULL) {
+            continue;
+        }
+        
+        if (strcmp(s_frogfs_vfs[i]->base_path, base_path) == 0) {
+            esp_err_t err = esp_vfs_unregister(base_path);
+            if (err != ESP_OK) {
+                return err;
             }
+            free(s_frogfs_vfs[i]);
+            s_frogfs_vfs[i] = NULL;
+            return ESP_OK;
         }
     }
     return ESP_ERR_NOT_FOUND;


### PR DESCRIPTION
A VFS deregister function was missing if for example we want to properly unmount/mount a frogfs file after an update.