### PR TITLE
Update version in idf_component.yml

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -13,6 +13,20 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Inject version into idf_component.yml on tag
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME}"
+          echo "Injecting version ${VERSION} into idf_component.yml"
+          tmpfile="$(mktemp)"
+          # Remove any existing top-level version field, then prepend the new one
+          grep -v '^[[:space:]]*version:[[:space:]]*' idf_component.yml > "$tmpfile"
+          printf 'version: "%s"\n' "$VERSION" > idf_component.yml
+          cat "$tmpfile" >> idf_component.yml
+          rm -f "$tmpfile"
+          echo "Resulting idf_component.yml:" && cat idf_component.yml
       - name: Upload component to the registry
         uses: espressif/upload-components-ci-action@v1
         with:

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "git"
+version: "0.0.1+main"
 description: A read-only file system for embedded use.
 url: https://github.com/jkent/frogfs
 dependencies:

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,3 @@
-version: "0.0.1+main"
 description: A read-only file system for embedded use.
 url: https://github.com/jkent/frogfs
 dependencies:


### PR DESCRIPTION
We wanted to use the `frogfs_vfs_deregister` function that has been added in commit b1e50d83d83e13da56622c63ce1470ed15bbc53e, but this version was not given a proper version tag. 

We could not directly get the repo by commit hash, because on the main branch a wrong version was given, resulting with the following error message: `Invalid field "version": Invalid version string: "git"`.

We gave version for the main branch in the proper format.