### PR TITLE
Make FrogFS standalone builds self‑contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ virtualenv via CMake:
 target_add_frogfs(${PROJECT_NAME}.elf
     # CONFIG and NAME as before
     REQUIREMENTS ${CMAKE_SOURCE_DIR}/tools/frogfs-extra-requirements.txt
-    PIP "heatshrink2>=0.10.0"
+    PIP "heatshrink2>=0.13.0"
 )
 ```
 `REQUIREMENTS` points to an additional requirements file, and `PIP` accepts a
@@ -160,9 +160,6 @@ virtualenv used by `mkfrogfs.py`. This helps enable optional features like
 - `python_requirements`: a path or list of paths to `requirements.txt` files.
 - `python_packages`: a list of requirement specifiers (e.g. `pkg`, `pkg==1.2`).
 
-The same options are also supported under a nested `python:` section as
-`python.requirements` and `python.packages`.
-
 Example:
 
 ```yaml
@@ -177,14 +174,13 @@ filter:
       - compress heatshrink: { window: 11, lookahead: 4 }
 
 # Install heatshrink2 into the build venv
-python_packages:
-  - heatshrink2>=0.10.0
+python_requirements:
+   - tools/frogfs-extra-requirements.txt
 
-# Or, alternatively:
-# python:
-#   requirements: tools/frogfs-extra-requirements.txt
-#   packages:
-#     - heatshrink2
+# or
+
+python_packages:
+  - heatshrink2>=0.13.0
 ```
 
 When these settings are present, `mkfrogfs.py` installs them into the same

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -6,7 +6,7 @@ macro(generate_frogfs_rules)
         set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
     endif()
 
-    cmake_parse_arguments(ARG "" "CONFIG;NAME" "TOOLS" ${ARGN})
+    cmake_parse_arguments(ARG "" "CONFIG;NAME;REQUIREMENTS" "TOOLS;PIP" ${ARGN})
     if(NOT DEFINED ARG_CONFIG)
         set(ARG_CONFIG frogfs.yaml)
     endif()
@@ -39,8 +39,10 @@ macro(generate_frogfs_rules)
     if (NOT TARGET frogfs_requirements)
         add_custom_target(frogfs_requirements
             COMMAND ${Python3_VENV_EXECUTABLE} -m pip install -r ${frogfs_DIR}/requirements.txt
+            $<$<BOOL:${ARG_REQUIREMENTS}>:${Python3_VENV_EXECUTABLE} -m pip install -r ${ARG_REQUIREMENTS}>
+            $<$<BOOL:"${ARG_PIP}">:${Python3_VENV_EXECUTABLE} -m pip install ${ARG_PIP}>
             COMMAND ${CMAKE_COMMAND} -E touch ${Python3_VENV}.stamp
-            DEPENDS ${frogfs_DIR}/requirements.txt
+            DEPENDS ${frogfs_DIR}/requirements.txt $<$<BOOL:${ARG_REQUIREMENTS}>:${ARG_REQUIREMENTS}>
             BYPRODUCTS ${Python3_VENV}.stamp
             COMMENT "Installing Python requirements"
         )
@@ -55,15 +57,14 @@ macro(generate_frogfs_rules)
         COMMENT "Running mkfrogfs.py for ${ARG_NAME}.bin"
         USES_TERMINAL
     )
+    add_dependencies(frogfs_preprocess_${ARG_NAME} frogfs_requirements)
 
     file(GLOB_RECURSE cache LIST_DIRECTORIES true CONFIGURE_DEPENDS "${BUILD_DIR}/${ARG_NAME}-cache/*")
     set_property(TARGET frogfs_preprocess_${ARG_NAME} PROPERTY ADDITIONAL_CLEAN_FILES "${cache}")
     file(GLOB_RECURSE node_modules FOLLOW_SYMLINKS LIST_DIRECTORIES true CONFIGURE_DEPENDS "${BUILD_DIR}/node_modules/*")
     set_property(TARGET frogfs_preprocess_${ARG_NAME} APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${node_modules};${BUILD_DIR}/node_modules")
 
-    if (${frogfs_DIR}/requirements.txt IS_NEWER_THAN ${Python3_VENV}.stamp)
-        add_dependencies(frogfs_preprocess_${ARG_NAME} frogfs_requirements)
-    endif()
+    # Always ensure Python requirements are installed before preprocess
 endmacro()
 
 function(target_add_frogfs target)

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -36,11 +36,19 @@ macro(generate_frogfs_rules)
         set_property(TARGET frogfs_venv PROPERTY ADDITIONAL_CLEAN_FILES "${venv}")
     endif()
 
+    # Build the commands list for requirements installation
+    set(_frogfs_req_cmds)
+    list(APPEND _frogfs_req_cmds COMMAND ${Python3_VENV_EXECUTABLE} -m pip install -r ${frogfs_DIR}/requirements.txt)
+    if (ARG_REQUIREMENTS)
+        list(APPEND _frogfs_req_cmds COMMAND ${Python3_VENV_EXECUTABLE} -m pip install -r ${ARG_REQUIREMENTS})
+    endif()
+    if (ARG_PIP)
+        list(APPEND _frogfs_req_cmds COMMAND ${Python3_VENV_EXECUTABLE} -m pip install ${ARG_PIP})
+    endif()
+
     if (NOT TARGET frogfs_requirements)
         add_custom_target(frogfs_requirements
-            COMMAND ${Python3_VENV_EXECUTABLE} -m pip install -r ${frogfs_DIR}/requirements.txt
-            $<$<BOOL:${ARG_REQUIREMENTS}>:${Python3_VENV_EXECUTABLE} -m pip install -r ${ARG_REQUIREMENTS}>
-            $<$<BOOL:"${ARG_PIP}">:${Python3_VENV_EXECUTABLE} -m pip install ${ARG_PIP}>
+            ${_frogfs_req_cmds}
             COMMAND ${CMAKE_COMMAND} -E touch ${Python3_VENV}.stamp
             DEPENDS ${frogfs_DIR}/requirements.txt $<$<BOOL:${ARG_REQUIREMENTS}>:${ARG_REQUIREMENTS}>
             BYPRODUCTS ${Python3_VENV}.stamp

--- a/frogfs_example.yaml
+++ b/frogfs_example.yaml
@@ -31,13 +31,10 @@ filter:
     - no compress
 
 # Optional: install extra Python deps into venv for mkfrogfs
+# python_requirements:
+#   - tools/frogfs-extra-requirements.txt
 # python_packages:
-#   - heatshrink2>=0.10.0
-# Or:
-# python:
-#   requirements: tools/frogfs-extra-requirements.txt
-#   packages:
-#     - heatshrink2
+#   - heatshrink2>=0.13.0
 
   '*.js':
     - gzip

--- a/frogfs_example.yaml
+++ b/frogfs_example.yaml
@@ -30,6 +30,15 @@ filter:
         ext: br
     - no compress
 
+# Optional: install extra Python deps into venv for mkfrogfs
+# python_packages:
+#   - heatshrink2>=0.10.0
+# Or:
+# python:
+#   requirements: tools/frogfs-extra-requirements.txt
+#   packages:
+#     - heatshrink2
+
   '*.js':
     - gzip
     - rename

--- a/tools/mkfrogfs.py
+++ b/tools/mkfrogfs.py
@@ -97,8 +97,7 @@ def load_config() -> dict:
     else:
         raise Exception('unexpected type for filter')
 
-    # Optional: extra python dependencies (top-level or under 'python')
-    pycfg = doc.get('python', {}) or {}
+    # Optional: extra python dependencies
 
     def _normalize_requirements(val):
         if not val:
@@ -118,13 +117,9 @@ def load_config() -> dict:
             return list(val)
         raise Exception('unexpected type for python packages')
 
-    reqs = []
-    # Support both top-level and nested keys
-    reqs += _normalize_requirements(doc.get('python_requirements'))
-    reqs += _normalize_requirements(pycfg.get('requirements'))
-    pkgs = []
-    pkgs += _normalize_packages(doc.get('python_packages'))
-    pkgs += _normalize_packages(pycfg.get('packages'))
+    # Enforce single style: top-level keys only
+    reqs = _normalize_requirements(doc.get('python_requirements'))
+    pkgs = _normalize_packages(doc.get('python_packages'))
 
     # Expand variables in paths and values
     reqs = [expand_variables(r, config['define']) for r in reqs]

--- a/tools/mkfrogfs.py
+++ b/tools/mkfrogfs.py
@@ -752,7 +752,6 @@ if __name__ == '__main__':
     install_extra_python_deps()
     # Re-attempt optional imports that may now be satisfied
     try:
-        global heatshrink2
         if heatshrink2 is None:
             import importlib
             heatshrink2 = importlib.import_module('heatshrink2')

--- a/tools/mkfrogfs.py
+++ b/tools/mkfrogfs.py
@@ -5,6 +5,9 @@ import json
 import os
 import zlib
 from argparse import ArgumentParser
+import subprocess
+import sys
+import hashlib
 from fnmatch import fnmatch
 from glob import glob
 from sys import stderr
@@ -30,7 +33,8 @@ def load_config() -> dict:
     with open(config_file, 'r') as f:
         doc = yaml.safe_load(f)
 
-    config = {'define': {}, 'collect': {}, 'filter': []}
+    config = {'define': {}, 'collect': {}, 'filter': [],
+              'python_requirements': [], 'python_packages': []}
 
     def add_define(name, value):
         value = expand_variables(value, config['define'])
@@ -92,6 +96,40 @@ def load_config() -> dict:
             add_filter(pattern, actions)
     else:
         raise Exception('unexpected type for filter')
+
+    # Optional: extra python dependencies (top-level or under 'python')
+    pycfg = doc.get('python', {}) or {}
+
+    def _normalize_requirements(val):
+        if not val:
+            return []
+        if isinstance(val, str):
+            return [val]
+        if isinstance(val, list):
+            return list(val)
+        raise Exception('unexpected type for python requirements')
+
+    def _normalize_packages(val):
+        if not val:
+            return []
+        if isinstance(val, str):
+            return [val]
+        if isinstance(val, list):
+            return list(val)
+        raise Exception('unexpected type for python packages')
+
+    reqs = []
+    # Support both top-level and nested keys
+    reqs += _normalize_requirements(doc.get('python_requirements'))
+    reqs += _normalize_requirements(pycfg.get('requirements'))
+    pkgs = []
+    pkgs += _normalize_packages(doc.get('python_packages'))
+    pkgs += _normalize_packages(pycfg.get('packages'))
+
+    # Expand variables in paths and values
+    reqs = [expand_variables(r, config['define']) for r in reqs]
+    config['python_requirements'] = reqs
+    config['python_packages'] = pkgs
 
     return config
 
@@ -661,6 +699,66 @@ if __name__ == '__main__':
     # Initial setup
     config  = load_config()
     entries = collect_entries()
+    # Optionally install extra Python deps defined in config
+    def install_extra_python_deps() -> None:
+        # No-ops if nothing specified
+        req_files = config.get('python_requirements', []) or []
+        pkgs = config.get('python_packages', []) or []
+        if not req_files and not pkgs:
+            return
+
+        # Build a content hash of requirements + packages to avoid redundant installs
+        h = hashlib.sha256()
+        for rf in sorted(req_files):
+            try:
+                with open(rf, 'rb') as f:
+                    h.update(b'F:')
+                    h.update(os.path.abspath(rf).encode('utf-8'))
+                    h.update(b'\0')
+                    h.update(f.read())
+                    h.update(b'\n')
+            except FileNotFoundError:
+                raise Exception(f'python_requirements file not found: {rf}')
+        for p in sorted(pkgs):
+            h.update(b'P:')
+            h.update(p.encode('utf-8'))
+            h.update(b'\n')
+
+        stamp_dir = build_dir
+        os.makedirs(stamp_dir, exist_ok=True)
+        stamp_file = os.path.join(stamp_dir, 'frogfs-venv-extra.stamp')
+        new_digest = h.hexdigest()
+        old_digest = None
+        try:
+            with open(stamp_file, 'r') as sf:
+                old_digest = sf.read().strip()
+        except Exception:
+            pass
+
+        if old_digest == new_digest:
+            return
+
+        # Install requirements files first
+        for rf in req_files:
+            subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', rf])
+
+        # Then named packages (if any)
+        if pkgs:
+            subprocess.check_call([sys.executable, '-m', 'pip', 'install', *pkgs])
+
+        with open(stamp_file, 'w') as sf:
+            sf.write(new_digest)
+
+    install_extra_python_deps()
+    # Re-attempt optional imports that may now be satisfied
+    try:
+        global heatshrink2
+        if heatshrink2 is None:
+            import importlib
+            heatshrink2 = importlib.import_module('heatshrink2')
+    except Exception:
+        pass
+
     transforms = load_transforms()
     discards = {}
     dirty = False


### PR DESCRIPTION
# Make FrogFS standalone builds self‑contained

optional Python deps via YAML and CMake (fix missing heatshrink2 in venv)

## Motivation

### Problem

The build venv did not include heatshrink2, so compress heatshrink rules failed unless we preinstalled it manually. In our CI we build a GUI binary without ESP‑IDF and deploy it automatically, so the FrogFS toolchain must work entirely standalone.

### Goal

Allow projects to declare extra Python packages/requirements that are installed into the FrogFS build virtualenv so optional compressors (like heatshrink) “just work” without global pip state.

## How We Use FrogFS Today

- Build the web app, collect artifacts into a resources dir, and compress almost everything with heatshrink:

```yaml
frogfs.yaml declares
collect:
  - $cwd/resources/
filter:
  '*':
    - compress heatshrink
```

- We add

```yaml
python_packages:
  - heatshrink2>=0.13.0
```

so the compressor is available at build time.

- Minimal CMake driving only the FrogFS binary generation (no ESP‑IDF):

```cmake
include(frogfs/cmake/functions.cmake)
declare_frogfs_bin(NAME gui)
```

- CI step builds `generate_gui_bin` and publishes `build/CMakeFiles/gui.bin`.

- Our deploy system consumes `gui.bin` directly, so FrogFS must bootstrap its own Python deps in its venv for a hermetic, automated pipeline.

## What Changed

### tools

- `tools/mkfrogfs.py`: installs extra Python deps declared in `frogfs.yaml` into the FrogFS build venv, with caching.
- Adds config keys: `python_requirements` and `python_packages` (also supported under a nested `python:` block as `python.requirements` and `python.packages`).
- Content‑hash caching to avoid redundant installs; stored as `frogfs-venv-extra.stamp`.
- Re‑attempts importing `heatshrink2` after installs.

### CMake

- `cmake/functions.cmake`: expose two new args to preinstall extras into the venv:
  - `REQUIREMENTS <path>`: additional requirements.txt.
  - `PIP "<specs...>"`: space‑separated requirement specifiers.

## Why This Solves the Issue

Declaring

```yaml
python_packages: [heatshrink2>=0.13.0]
```

in `frogfs.yaml` ensures `mkfrogfs.py` installs the compressor into the FrogFS venv before preprocessing. No more reliance on global environment or ESP‑IDF.

The same is achievable from CMake using `REQUIREMENTS` and/or `PIP` for projects that prefer not to modify `frogfs.yaml`.

Builds remain reproducible and hermetic; caching avoids repeated installs.

## Usage Examples

### YAML (project‑local, CI‑friendly)

```yaml
frogfs.yaml:
python_packages:
  - heatshrink2>=0.13.0
filter:
  '*':
    - compress heatshrink
```

### CMake (centralized control)

```cmake
target_add_frogfs(... REQUIREMENTS ${CMAKE_SOURCE_DIR}/tools/frogfs-extra-requirements.txt PIP "heatshrink2>=0.13.0")
```

### Standalone build

Declare

```cmake
declare_frogfs_bin(NAME gui)
```

then

```bash
cmake --build <build> --target <target>
```

artifact at `<build>/CMakeFiles/<NAME>.bin`.
